### PR TITLE
Consolidate error reporting

### DIFF
--- a/ibis/compiler.py
+++ b/ibis/compiler.py
@@ -169,12 +169,10 @@ class Parser:
                     expecting.append(endword)
             elif token.keyword in nodes.instruction_endwords:
                 if len(expecting) == 0:
-                    msg = f"Unexpected '{token.keyword}' tag in template '{token.template_id}', "
-                    msg += f"line {token.line_number}."
+                    msg = f"Unexpected tag"
                     raise errors.TemplateSyntaxError(msg, token)
                 elif expecting[-1] != token.keyword:
-                    msg = f"Unexpected '{token.keyword}' tag in template '{token.template_id}', "
-                    msg += f"line {token.line_number}. "
+                    msg = f"Unexpected '{token.keyword}' tag. "
                     msg += f"Ibis was expecting the following closing tag: '{expecting[-1]}'."
                     raise errors.TemplateSyntaxError(msg, token)
                 else:
@@ -182,17 +180,15 @@ class Parser:
                     stack.pop()
                     expecting.pop()
             elif token.keyword == '':
-                msg = f"Empty instruction tag in template '{token.template_id}', "
-                msg += f"line {token.line_number}."
+                msg = f"Empty instruction tag"
                 raise errors.TemplateSyntaxError(msg, token)
             else:
-                msg = f"Unrecognised instruction tag '{token.keyword}' "
-                msg += f"in template '{token.template_id}', line {token.line_number}."
+                msg = f"Unrecognised instruction tag"
                 raise errors.TemplateSyntaxError(msg, token)
 
         if expecting:
             token = stack[-1].token
-            msg = f"Unexpected end of template '{self.template_id}'. "
+            msg = f"Unexpected end of template. "
             msg += f"Ibis was expecting a closing tag '{expecting[-1]}' to close the "
             msg += f"'{token.keyword}' tag opened in line {token.line_number}."
             raise errors.TemplateSyntaxError(msg, token)

--- a/ibis/context.py
+++ b/ibis/context.py
@@ -88,8 +88,7 @@ class Context:
                         result = result[int(word)]
                     except:
                         if self.strict_mode:
-                            msg = f"Cannot resolve the variable '{'.'.join(words)}' in template "
-                            msg += f"'{token.template_id}', line {token.line_number}."
+                            msg = f"Cannot resolve the variable '{'.'.join(words)}'"
                             raise errors.UndefinedVariable(msg, token) from None
                         return Undefined()
         return result

--- a/ibis/errors.py
+++ b/ibis/errors.py
@@ -16,26 +16,27 @@ class TemplateLexingError(TemplateError):
         self.template_id = template_id
 
 
-# This exception type may be raised while a template is being compiled.
-class TemplateSyntaxError(TemplateError):
-
+class TemplateErrorWithToken(TemplateError):
     def __init__(self, msg, token):
         super().__init__(msg)
+        self.msg = msg
         self.token = token
+
+    def __str__(self):
+        token = self.token
+        return f'{self.msg} ({token.template_id}, line {token.line_number}, in "{token.keyword}")'
+
+
+# This exception type may be raised while a template is being compiled.
+class TemplateSyntaxError(TemplateErrorWithToken):
+    pass
 
 
 # This exception type may be raised while a template is being rendered.
-class TemplateRenderingError(TemplateError):
-
-    def __init__(self, msg, token):
-        super().__init__(msg)
-        self.token = token
+class TemplateRenderingError(TemplateErrorWithToken):
+    pass
 
 
 # This exception type is raised in strict mode if a variable cannot be resolved.
-class UndefinedVariable(TemplateError):
-
-    def __init__(self, msg, token):
-        super().__init__(msg)
-        self.token = token
-
+class UndefinedVariable(TemplateErrorWithToken):
+    pass

--- a/ibis/errors.py
+++ b/ibis/errors.py
@@ -16,7 +16,7 @@ class TemplateLexingError(TemplateError):
         self.template_id = template_id
 
 
-class TemplateErrorWithToken(TemplateError):
+class ErrorWithToken(TemplateError):
     def __init__(self, msg, token):
         super().__init__(msg)
         self.msg = msg
@@ -28,15 +28,15 @@ class TemplateErrorWithToken(TemplateError):
 
 
 # This exception type may be raised while a template is being compiled.
-class TemplateSyntaxError(TemplateErrorWithToken):
+class TemplateSyntaxError(ErrorWithToken):
     pass
 
 
 # This exception type may be raised while a template is being rendered.
-class TemplateRenderingError(TemplateErrorWithToken):
+class TemplateRenderingError(ErrorWithToken):
     pass
 
 
 # This exception type is raised in strict mode if a variable cannot be resolved.
-class UndefinedVariable(TemplateErrorWithToken):
+class UndefinedVariable(ErrorWithToken):
     pass


### PR DESCRIPTION
This code moves the formatting logic of a template error into the exception class itself. The reasons are:

- Reduce the code needed to raise an error
- Ensure that exception formatting is consistent
- Store the exception message as its own attribute. For example, the application might want to output the exception location not in text form (like "foo/bar/template.html, line 57, in include"), but might actually load the template and point to the line with the error.
